### PR TITLE
Feature: 3-Strike Retry System

### DIFF
--- a/__tests__/engine/numberSelector.errorWeight.test.ts
+++ b/__tests__/engine/numberSelector.errorWeight.test.ts
@@ -1,0 +1,53 @@
+import { selectNextNumber } from '@/engine/numberSelector';
+import { NumberStats } from '@/types/game';
+
+const s = (o: Partial<NumberStats> = {}): NumberStats => ({
+  correct: 0, wrong: 0, lastPlayed: 0, countingCorrect: 0, feedCorrect: 0, bubblesCorrect: 0, ...o,
+});
+
+describe('numberSelector error-ratio weighting', () => {
+  it('numbers with high error ratios get higher weights (statistical)', () => {
+    // Set up: numbers 1-9 mastered, number 10 with high error ratio (practiced, not mastered)
+    const m: Record<string, NumberStats> = {};
+    for (let n = 1; n <= 9; n++) m[String(n)] = s({ correct: 5, lastPlayed: Date.now() });
+    // Number 10: 0 correct, 5 wrong → error ratio 1.0 → weight = 7 + 8 = 15
+    m['10'] = s({ wrong: 5, lastPlayed: Date.now() });
+
+    let count10 = 0;
+    for (let i = 0; i < 500; i++) {
+      if (selectNextNumber(m, [1, 10]) === 10) count10++;
+    }
+    // With weight 15 vs mastered ~2-5, number 10 should be picked very frequently
+    expect(count10 / 500).toBeGreaterThan(0.3);
+  });
+
+  it('100% error rate number has weight > unplayed number (weight 10)', () => {
+    // Number 1: unplayed → weight 10
+    // Number 2: 100% wrong (0 correct, 6 wrong, not mastered) → weight 7 + 8 = 15
+    const m: Record<string, NumberStats> = {
+      '2': s({ wrong: 6, lastPlayed: Date.now() }),
+    };
+
+    let count2 = 0;
+    for (let i = 0; i < 1000; i++) {
+      if (selectNextNumber(m, [1, 2]) === 2) count2++;
+    }
+    // Weight 15 vs 10 → number 2 should be picked ~60% of the time
+    expect(count2 / 1000).toBeGreaterThan(0.5);
+  });
+
+  it('33% error rate adds moderate weight boost', () => {
+    // 2 correct, 1 wrong → errorRatio = 0.333 → weight = 7 + round(0.333 * 8) = 7 + 3 = 10
+    const m: Record<string, NumberStats> = {
+      '1': s({ correct: 2, wrong: 1, lastPlayed: Date.now() }),
+      '2': s({ correct: 5, lastPlayed: Date.now() }), // mastered → weight ~2-5
+    };
+
+    let count1 = 0;
+    for (let i = 0; i < 500; i++) {
+      if (selectNextNumber(m, [1, 2]) === 1) count1++;
+    }
+    // Weight ~10 vs ~2-5 → number 1 should dominate
+    expect(count1 / 500).toBeGreaterThan(0.5);
+  });
+});

--- a/__tests__/hooks/useStrikeOut.test.ts
+++ b/__tests__/hooks/useStrikeOut.test.ts
@@ -1,0 +1,212 @@
+import { generateDistractors } from '@/engine/distractors';
+import { MAX_ANSWER_ATTEMPTS } from '@/data/thresholds';
+
+/**
+ * Tests for the 3-strike retry system.
+ * Since renderHook is not available, we simulate the state machine logic
+ * that the hooks implement, verifying the strike-out flow.
+ */
+
+interface CountingState {
+  phase: string;
+  targetNumber: number;
+  tappedIndices: Set<number>;
+  answerChoices: [number, number, number];
+  attempts: number;
+}
+
+interface BubblesState {
+  phase: string;
+  targetNumber: number;
+  poppedCount: number;
+  answerChoices: [number, number, number];
+  attempts: number;
+}
+
+interface FeedingState {
+  phase: string;
+  targetNumber: number;
+  fedIndices: number[];
+  answerChoices: [number, number, number];
+  attempts: number;
+}
+
+// Simulate the selectAnswer logic from the hooks
+function simulateWrongAnswer(state: { phase: string; attempts: number }) {
+  if (state.phase !== 'answering') return state;
+  const newAttempts = state.attempts + 1;
+  if (newAttempts >= MAX_ANSWER_ATTEMPTS) {
+    return { ...state, phase: 'strike_out', attempts: newAttempts };
+  }
+  return { ...state, phase: 'wrong', attempts: newAttempts };
+}
+
+function simulateRetry(state: { phase: string }) {
+  if (state.phase !== 'wrong') return state;
+  return { ...state, phase: 'answering' };
+}
+
+describe('3-Strike Retry System', () => {
+  describe('MAX_ANSWER_ATTEMPTS constant', () => {
+    it('is set to 3', () => {
+      expect(MAX_ANSWER_ATTEMPTS).toBe(3);
+    });
+  });
+
+  describe('strike-out phase transition', () => {
+    it('transitions to strike_out after MAX_ANSWER_ATTEMPTS wrong answers', () => {
+      let state = { phase: 'answering', attempts: 0 };
+
+      // First wrong answer → wrong phase
+      state = simulateWrongAnswer(state);
+      expect(state.phase).toBe('wrong');
+      expect(state.attempts).toBe(1);
+
+      // Retry → back to answering
+      state = simulateRetry(state);
+      expect(state.phase).toBe('answering');
+
+      // Second wrong answer → wrong phase
+      state = simulateWrongAnswer(state);
+      expect(state.phase).toBe('wrong');
+      expect(state.attempts).toBe(2);
+
+      // Retry → back to answering
+      state = simulateRetry(state);
+      expect(state.phase).toBe('answering');
+
+      // Third wrong answer → strike_out phase
+      state = simulateWrongAnswer(state);
+      expect(state.phase).toBe('strike_out');
+      expect(state.attempts).toBe(3);
+    });
+
+    it('does not transition to strike_out before MAX_ANSWER_ATTEMPTS', () => {
+      let state = { phase: 'answering', attempts: 0 };
+
+      for (let i = 0; i < MAX_ANSWER_ATTEMPTS - 1; i++) {
+        state = simulateWrongAnswer(state);
+        expect(state.phase).not.toBe('strike_out');
+        state = simulateRetry(state);
+      }
+    });
+  });
+
+  describe('restartSameRound for counting game', () => {
+    it('resets tapped state but keeps same target number', () => {
+      const target = 5;
+      const choices = generateDistractors(target);
+
+      const strikeOutState: CountingState = {
+        phase: 'strike_out',
+        targetNumber: target,
+        tappedIndices: new Set([0, 1, 2, 3, 4]),
+        answerChoices: choices,
+        attempts: MAX_ANSWER_ATTEMPTS,
+      };
+
+      // Simulate restartSameRound
+      const newChoices = generateDistractors(strikeOutState.targetNumber);
+      const restarted: CountingState = {
+        ...strikeOutState,
+        phase: 'tapping',
+        tappedIndices: new Set<number>(),
+        answerChoices: newChoices,
+        attempts: 0,
+      };
+
+      expect(restarted.phase).toBe('tapping');
+      expect(restarted.targetNumber).toBe(target);
+      expect(restarted.tappedIndices.size).toBe(0);
+      expect(restarted.attempts).toBe(0);
+      expect(restarted.answerChoices).toContain(target);
+    });
+  });
+
+  describe('restartSameRound for bubbles game', () => {
+    it('resets popped state but keeps same target number', () => {
+      const target = 7;
+
+      const strikeOutState: BubblesState = {
+        phase: 'strike_out',
+        targetNumber: target,
+        poppedCount: target,
+        answerChoices: generateDistractors(target),
+        attempts: MAX_ANSWER_ATTEMPTS,
+      };
+
+      const newChoices = generateDistractors(strikeOutState.targetNumber);
+      const restarted: BubblesState = {
+        ...strikeOutState,
+        phase: 'popping',
+        poppedCount: 0,
+        answerChoices: newChoices,
+        attempts: 0,
+      };
+
+      expect(restarted.phase).toBe('popping');
+      expect(restarted.targetNumber).toBe(target);
+      expect(restarted.poppedCount).toBe(0);
+      expect(restarted.attempts).toBe(0);
+    });
+  });
+
+  describe('restartSameRound for feeding game', () => {
+    it('resets fed state but keeps same target number', () => {
+      const target = 4;
+
+      const strikeOutState: FeedingState = {
+        phase: 'strike_out',
+        targetNumber: target,
+        fedIndices: [0, 1, 2, 3],
+        answerChoices: generateDistractors(target),
+        attempts: MAX_ANSWER_ATTEMPTS,
+      };
+
+      const newChoices = generateDistractors(strikeOutState.targetNumber);
+      const restarted: FeedingState = {
+        ...strikeOutState,
+        phase: 'feeding',
+        fedIndices: [],
+        answerChoices: newChoices,
+        attempts: 0,
+      };
+
+      expect(restarted.phase).toBe('feeding');
+      expect(restarted.targetNumber).toBe(target);
+      expect(restarted.fedIndices).toHaveLength(0);
+      expect(restarted.attempts).toBe(0);
+    });
+  });
+
+  describe('attempts counter reset', () => {
+    it('resets to 0 after restartSameRound', () => {
+      let state = { phase: 'answering', attempts: 0 };
+
+      // Get to strike_out
+      for (let i = 0; i < MAX_ANSWER_ATTEMPTS; i++) {
+        state = simulateWrongAnswer(state);
+        if (state.phase === 'wrong') state = simulateRetry(state);
+      }
+
+      expect(state.attempts).toBe(MAX_ANSWER_ATTEMPTS);
+
+      // Simulate restart
+      const restarted = { ...state, phase: 'tapping', attempts: 0 };
+      expect(restarted.attempts).toBe(0);
+    });
+  });
+
+  describe('restartSameRound only works from strike_out phase', () => {
+    it('does not restart from other phases', () => {
+      const phases = ['idle', 'tapping', 'answering', 'correct', 'wrong', 'complete'];
+      for (const phase of phases) {
+        const state = { phase, targetNumber: 5 };
+        // restartSameRound guard: if (prev.phase !== 'strike_out') return prev
+        if (state.phase !== 'strike_out') {
+          expect(state.phase).not.toBe('strike_out');
+        }
+      }
+    });
+  });
+});

--- a/app/game/bubbles.tsx
+++ b/app/game/bubbles.tsx
@@ -10,6 +10,7 @@ import { getAnimalForNumber } from '@/data/animals';
 import { getRandomWrongPhrase } from '@/data/phrases';
 import { COLORS } from '@/data/colors';
 import { FloorId } from '@/types/game';
+import { MAX_ANSWER_ATTEMPTS } from '@/data/thresholds';
 
 export default function BubblesGame() {
   const params = useLocalSearchParams<{ floorId: string }>();
@@ -17,7 +18,7 @@ export default function BubblesGame() {
 
   const {
     phase, targetNumber, poppedCount, answerChoices, attempts,
-    startRound, popBubble, selectAnswer, retryAnswer, completeRound,
+    startRound, popBubble, selectAnswer, retryAnswer, restartSameRound, completeRound,
   } = useBubblesGame(floorId);
 
   const [roundNumber, setRoundNumber] = useState(1);
@@ -34,14 +35,24 @@ export default function BubblesGame() {
     }
   }, [phase]);
 
-  // Auto-retry after wrong answer
+  // Auto-retry after wrong answer (only if not at max attempts)
   useEffect(() => {
     if (phase === 'wrong') {
       setWrongPhrase(getRandomWrongPhrase());
-      const timer = setTimeout(retryAnswer, 800);
+      if (attempts < MAX_ANSWER_ATTEMPTS) {
+        const timer = setTimeout(retryAnswer, 800);
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [phase, retryAnswer, attempts]);
+
+  // Strike-out: auto-advance after delay
+  useEffect(() => {
+    if (phase === 'strike_out') {
+      const timer = setTimeout(restartSameRound, 1500);
       return () => clearTimeout(timer);
     }
-  }, [phase, retryAnswer]);
+  }, [phase, restartSameRound]);
 
   // Navigate to star award on correct
   useEffect(() => {
@@ -143,9 +154,28 @@ export default function BubblesGame() {
               />
             ))}
           </View>
+          {/* Strike indicator */}
+          <View style={styles.strikeRow}>
+            {Array.from({ length: MAX_ANSWER_ATTEMPTS }, (_, i) => (
+              <View
+                key={i}
+                style={[
+                  styles.strikeDot,
+                  i < attempts ? styles.strikeDotFilled : styles.strikeDotEmpty,
+                ]}
+              />
+            ))}
+          </View>
           {phase === 'wrong' && (
             <Text style={styles.tryAgain}>{wrongPhrase}</Text>
           )}
+        </View>
+      )}
+
+      {/* Strike-out overlay */}
+      {phase === 'strike_out' && (
+        <View style={styles.strikeOutOverlay}>
+          <Text style={styles.strikeOutText}>Let's try again!</Text>
         </View>
       )}
 
@@ -246,5 +276,35 @@ const styles = StyleSheet.create({
     color: COLORS.wrong,
     marginTop: 12,
     fontStyle: 'italic',
+  },
+  strikeRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 12,
+    justifyContent: 'center',
+  },
+  strikeDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  strikeDotFilled: {
+    backgroundColor: COLORS.textPrimary,
+  },
+  strikeDotEmpty: {
+    borderWidth: 1.5,
+    borderColor: COLORS.textSecondary,
+    backgroundColor: 'transparent',
+  },
+  strikeOutOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.3)',
+  },
+  strikeOutText: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#E8A838',
   },
 });

--- a/app/game/counting.tsx
+++ b/app/game/counting.tsx
@@ -11,6 +11,7 @@ import { getAnimalForNumber } from '@/data/animals';
 import { getRandomWrongPhrase } from '@/data/phrases';
 import { COLORS } from '@/data/colors';
 import { FloorId } from '@/types/game';
+import { MAX_ANSWER_ATTEMPTS } from '@/data/thresholds';
 
 // Object emojis per floor theme
 const OBJECT_EMOJIS: Record<string, string[]> = {
@@ -25,7 +26,7 @@ export default function CountingGame() {
 
   const {
     phase, targetNumber, tappedCount, tappedIndices, answerChoices, attempts,
-    startRound, tapObject, selectAnswer, retryAnswer, completeRound,
+    startRound, tapObject, selectAnswer, retryAnswer, restartSameRound, completeRound,
   } = useCountingGame(floorId);
 
   // Start first round on mount
@@ -33,13 +34,21 @@ export default function CountingGame() {
     if (phase === 'idle') startRound();
   }, [phase, startRound]);
 
-  // Auto-retry after wrong answer shake
+  // Auto-retry after wrong answer shake (only if not at max attempts)
   useEffect(() => {
-    if (phase === 'wrong') {
+    if (phase === 'wrong' && attempts < MAX_ANSWER_ATTEMPTS) {
       const timer = setTimeout(retryAnswer, 800);
       return () => clearTimeout(timer);
     }
-  }, [phase, retryAnswer]);
+  }, [phase, retryAnswer, attempts]);
+
+  // Strike-out: auto-advance after delay
+  useEffect(() => {
+    if (phase === 'strike_out') {
+      const timer = setTimeout(restartSameRound, 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [phase, restartSameRound]);
 
   // Navigate to star award on correct
   useEffect(() => {
@@ -143,9 +152,28 @@ export default function CountingGame() {
               />
             ))}
           </View>
+          {/* Strike indicator */}
+          <View style={styles.strikeRow}>
+            {Array.from({ length: MAX_ANSWER_ATTEMPTS }, (_, i) => (
+              <View
+                key={i}
+                style={[
+                  styles.strikeDot,
+                  i < attempts ? styles.strikeDotFilled : styles.strikeDotEmpty,
+                ]}
+              />
+            ))}
+          </View>
           {phase === 'wrong' && (
             <Text style={styles.tryAgain}>Hmm, let's try again!</Text>
           )}
+        </View>
+      )}
+
+      {/* Strike-out overlay */}
+      {phase === 'strike_out' && (
+        <View style={styles.strikeOutOverlay}>
+          <Text style={styles.strikeOutText}>Let's try again!</Text>
         </View>
       )}
 
@@ -234,5 +262,35 @@ const styles = StyleSheet.create({
     color: COLORS.wrong,
     marginTop: 12,
     fontStyle: 'italic',
+  },
+  strikeRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 12,
+    justifyContent: 'center',
+  },
+  strikeDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  strikeDotFilled: {
+    backgroundColor: COLORS.textPrimary,
+  },
+  strikeDotEmpty: {
+    borderWidth: 1.5,
+    borderColor: COLORS.textSecondary,
+    backgroundColor: 'transparent',
+  },
+  strikeOutOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.3)',
+  },
+  strikeOutText: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#E8A838',
   },
 });

--- a/app/game/feeding.tsx
+++ b/app/game/feeding.tsx
@@ -11,6 +11,7 @@ import { getAnimalForNumber } from '@/data/animals';
 import { getRandomWrongPhrase } from '@/data/phrases';
 import { COLORS } from '@/data/colors';
 import { FloorId } from '@/types/game';
+import { MAX_ANSWER_ATTEMPTS } from '@/data/thresholds';
 
 export default function FeedingGame() {
   const params = useLocalSearchParams<{ floorId: string }>();
@@ -19,7 +20,7 @@ export default function FeedingGame() {
   const {
     phase, targetNumber, fedCount, fedIndices, answerChoices, attempts,
     startRound, feedTreat, undoTreat, selectAnswer, retryAnswer,
-    startTummyFull, completeRound,
+    restartSameRound, startTummyFull, completeRound,
   } = useFeedingGame(floorId);
 
   // Start first round on mount
@@ -27,14 +28,24 @@ export default function FeedingGame() {
     if (phase === 'idle') startRound();
   }, [phase, startRound]);
 
-  // Auto-retry after wrong answer
+  // Auto-retry after wrong answer (only if not at max attempts)
   useEffect(() => {
     if (phase === 'wrong') {
       setWrongPhrase(getRandomWrongPhrase());
-      const timer = setTimeout(retryAnswer, 800);
+      if (attempts < MAX_ANSWER_ATTEMPTS) {
+        const timer = setTimeout(retryAnswer, 800);
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [phase, retryAnswer, attempts]);
+
+  // Strike-out: auto-advance after delay
+  useEffect(() => {
+    if (phase === 'strike_out') {
+      const timer = setTimeout(restartSameRound, 1500);
       return () => clearTimeout(timer);
     }
-  }, [phase, retryAnswer]);
+  }, [phase, restartSameRound]);
 
   // Trigger tummy-full after correct
   useEffect(() => {
@@ -154,9 +165,28 @@ export default function FeedingGame() {
               />
             ))}
           </View>
+          {/* Strike indicator */}
+          <View style={styles.strikeRow}>
+            {Array.from({ length: MAX_ANSWER_ATTEMPTS }, (_, i) => (
+              <View
+                key={i}
+                style={[
+                  styles.strikeDot,
+                  i < attempts ? styles.strikeDotFilled : styles.strikeDotEmpty,
+                ]}
+              />
+            ))}
+          </View>
           {phase === 'wrong' && (
             <Text style={styles.tryAgain}>{wrongPhrase}</Text>
           )}
+        </View>
+      )}
+
+      {/* Strike-out overlay */}
+      {phase === 'strike_out' && (
+        <View style={styles.strikeOutOverlay}>
+          <Text style={styles.strikeOutText}>Let's try again!</Text>
         </View>
       )}
 
@@ -259,5 +289,35 @@ const styles = StyleSheet.create({
     color: COLORS.wrong,
     marginTop: 12,
     fontStyle: 'italic',
+  },
+  strikeRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 12,
+    justifyContent: 'center',
+  },
+  strikeDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  strikeDotFilled: {
+    backgroundColor: COLORS.textPrimary,
+  },
+  strikeDotEmpty: {
+    borderWidth: 1.5,
+    borderColor: COLORS.textSecondary,
+    backgroundColor: 'transparent',
+  },
+  strikeOutOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.3)',
+  },
+  strikeOutText: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#E8A838',
   },
 });

--- a/src/data/thresholds.ts
+++ b/src/data/thresholds.ts
@@ -12,3 +12,6 @@ export const FLOOR_MASTERY_PERCENT = 0.8;
 
 /** Maximum session log entries to keep */
 export const MAX_SESSION_LOG = 30;
+
+/** Maximum wrong-answer attempts before a strike-out restart */
+export const MAX_ANSWER_ATTEMPTS = 3;

--- a/src/engine/numberSelector.ts
+++ b/src/engine/numberSelector.ts
@@ -22,7 +22,15 @@ export function selectNextNumber(
   const weights = candidates.map((n) => {
     const stats = mastery[String(n)];
     if (!stats || (stats.correct === 0 && stats.wrong === 0)) return 10;
-    if (!isNumberMastered(stats)) return 7;
+    if (!isNumberMastered(stats)) {
+      let weight = 7;
+      const totalAttempts = stats.correct + stats.wrong;
+      if (totalAttempts > 0) {
+        const errorRatio = stats.wrong / totalAttempts;
+        weight += Math.round(errorRatio * 8);
+      }
+      return weight;
+    }
     const daysSinceLastPlayed =
       stats.lastPlayed > 0
         ? (Date.now() - stats.lastPlayed) / (1000 * 60 * 60 * 24)

--- a/src/hooks/useBubblesGame.ts
+++ b/src/hooks/useBubblesGame.ts
@@ -6,8 +6,9 @@ import { FloorId } from '@/types/game';
 import { FLOORS } from '@/data/floors';
 import { hapticTap, hapticSuccess, hapticError } from '@/utils/haptics';
 import { playSound } from '@/utils/audio';
+import { MAX_ANSWER_ATTEMPTS } from '@/data/thresholds';
 
-export type BubblesPhase = 'idle' | 'popping' | 'answering' | 'correct' | 'wrong' | 'complete';
+export type BubblesPhase = 'idle' | 'popping' | 'answering' | 'correct' | 'wrong' | 'strike_out' | 'complete';
 
 interface BubblesGameState {
   phase: BubblesPhase;
@@ -78,7 +79,11 @@ export function useBubblesGame(floorId: FloorId) {
           hapticError();
           playSound('wrong_answer');
           recordAnswer(prev.targetNumber, 'bubbles', false);
-          return { ...prev, phase: 'wrong', attempts: prev.attempts + 1 };
+          const newAttempts = prev.attempts + 1;
+          if (newAttempts >= MAX_ANSWER_ATTEMPTS) {
+            return { ...prev, phase: 'strike_out', attempts: newAttempts };
+          }
+          return { ...prev, phase: 'wrong', attempts: newAttempts };
         }
       });
     },
@@ -92,6 +97,20 @@ export function useBubblesGame(floorId: FloorId) {
     });
   }, []);
 
+  const restartSameRound = useCallback(() => {
+    setState((prev) => {
+      if (prev.phase !== 'strike_out') return prev;
+      const choices = generateDistractors(prev.targetNumber);
+      return {
+        ...prev,
+        phase: 'popping',
+        poppedCount: 0,
+        answerChoices: choices,
+        attempts: 0,
+      };
+    });
+  }, []);
+
   const completeRound = useCallback(() => {
     setState((prev) => ({ ...prev, phase: 'complete' }));
   }, []);
@@ -102,6 +121,7 @@ export function useBubblesGame(floorId: FloorId) {
     popBubble,
     selectAnswer,
     retryAnswer,
+    restartSameRound,
     completeRound,
   };
 }

--- a/src/hooks/useCountingGame.ts
+++ b/src/hooks/useCountingGame.ts
@@ -6,8 +6,9 @@ import { FloorId } from '@/types/game';
 import { FLOORS } from '@/data/floors';
 import { hapticTap, hapticSuccess, hapticError } from '@/utils/haptics';
 import { playSound } from '@/utils/audio';
+import { MAX_ANSWER_ATTEMPTS } from '@/data/thresholds';
 
-export type CountingPhase = 'idle' | 'tapping' | 'answering' | 'correct' | 'wrong' | 'complete';
+export type CountingPhase = 'idle' | 'tapping' | 'answering' | 'correct' | 'wrong' | 'strike_out' | 'complete';
 
 interface CountingGameState {
   phase: CountingPhase;
@@ -80,7 +81,11 @@ export function useCountingGame(floorId: FloorId) {
           hapticError();
           playSound('wrong_answer');
           recordAnswer(prev.targetNumber, 'counting', false);
-          return { ...prev, phase: 'wrong', attempts: prev.attempts + 1 };
+          const newAttempts = prev.attempts + 1;
+          if (newAttempts >= MAX_ANSWER_ATTEMPTS) {
+            return { ...prev, phase: 'strike_out', attempts: newAttempts };
+          }
+          return { ...prev, phase: 'wrong', attempts: newAttempts };
         }
       });
     },
@@ -91,6 +96,20 @@ export function useCountingGame(floorId: FloorId) {
     setState((prev) => {
       if (prev.phase !== 'wrong') return prev;
       return { ...prev, phase: 'answering' };
+    });
+  }, []);
+
+  const restartSameRound = useCallback(() => {
+    setState((prev) => {
+      if (prev.phase !== 'strike_out') return prev;
+      const choices = generateDistractors(prev.targetNumber);
+      return {
+        ...prev,
+        phase: 'tapping',
+        tappedIndices: new Set<number>(),
+        answerChoices: choices,
+        attempts: 0,
+      };
     });
   }, []);
 
@@ -105,6 +124,7 @@ export function useCountingGame(floorId: FloorId) {
     tapObject,
     selectAnswer,
     retryAnswer,
+    restartSameRound,
     completeRound,
   };
 }

--- a/src/hooks/useFeedingGame.ts
+++ b/src/hooks/useFeedingGame.ts
@@ -6,6 +6,7 @@ import { FloorId } from '@/types/game';
 import { FLOORS } from '@/data/floors';
 import { hapticTap, hapticSuccess, hapticError } from '@/utils/haptics';
 import { playSound } from '@/utils/audio';
+import { MAX_ANSWER_ATTEMPTS } from '@/data/thresholds';
 
 export type FeedingPhase =
   | 'idle'
@@ -14,6 +15,7 @@ export type FeedingPhase =
   | 'correct'
   | 'tummy_full'
   | 'wrong'
+  | 'strike_out'
   | 'complete';
 
 interface FeedingGameState {
@@ -93,7 +95,11 @@ export function useFeedingGame(floorId: FloorId) {
           hapticError();
           playSound('wrong_answer');
           recordAnswer(prev.targetNumber, 'feed', false);
-          return { ...prev, phase: 'wrong', attempts: prev.attempts + 1 };
+          const newAttempts = prev.attempts + 1;
+          if (newAttempts >= MAX_ANSWER_ATTEMPTS) {
+            return { ...prev, phase: 'strike_out', attempts: newAttempts };
+          }
+          return { ...prev, phase: 'wrong', attempts: newAttempts };
         }
       });
     },
@@ -115,6 +121,20 @@ export function useFeedingGame(floorId: FloorId) {
     });
   }, []);
 
+  const restartSameRound = useCallback(() => {
+    setState((prev) => {
+      if (prev.phase !== 'strike_out') return prev;
+      const choices = generateDistractors(prev.targetNumber);
+      return {
+        ...prev,
+        phase: 'feeding',
+        fedIndices: [],
+        answerChoices: choices,
+        attempts: 0,
+      };
+    });
+  }, []);
+
   const completeRound = useCallback(() => {
     setState((prev) => ({ ...prev, phase: 'complete' }));
   }, []);
@@ -127,6 +147,7 @@ export function useFeedingGame(floorId: FloorId) {
     undoTreat,
     selectAnswer,
     retryAnswer,
+    restartSameRound,
     startTummyFull,
     completeRound,
   };


### PR DESCRIPTION
## Summary
- Max 3 guesses per answer round across all 3 game mechanics
- Strike indicator (3 dots) below answer choices
- "Let's try again!" overlay on strike-out, restarts same round
- Error-ratio weighted number selector (struggled numbers appear more often)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)